### PR TITLE
spaces start

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ***
 [![Build Status](https://travis-ci.org/adastradev/astra-api-bridge.svg?branch=master)](https://travis-ci.org/adastradev/astra-api-bridge)
-[![Dependency Status](https://david-dm.org/adastradev/astra-api-facade.svg)](https://david-dm.org/adastradev/astra-api-facade)
-[![Dev Dependency Status](https://david-dm.org/adastradev/astra-api-facade/dev-status.svg)](https://david-dm.org/adastradev/astra-api-facade?type=dev)
+[![Dependency Status](https://david-dm.org/adastradev/astra-api-bridge.svg)](https://david-dm.org/adastradev/astra-api-bridge)
+[![Dev Dependency Status](https://david-dm.org/adastradev/astra-api-bridge/dev-status.svg)](https://david-dm.org/adastradev/astra-api-bridge?type=dev)
 
 This is a middleware solution that leverages the [facade pattern](https://en.wikipedia.org/wiki/Facade_pattern) to provide a simplified RESTful API on top of the existing Astra Schedule API
 
@@ -17,10 +17,10 @@ Configure your Astra Schedule envrionment with a username and password that can 
 
 #### 2. Clone the project
 
-`git clone https://github.com/adastradev/astra-api-facade.git`
+`git clone https://github.com/adastradev/astra-api-bridge.git`
 
 #### 3. Install all dependencies
-Change into the project directory (e.g. `cd astra-api-facade`) and run `npm install`
+Change into the project directory (e.g. `cd astra-api-bridge`) and run `npm install`
 
 #### 4. Configure authentication
 

--- a/bin/www
+++ b/bin/www
@@ -5,7 +5,7 @@
  */
 
 var app = require('../app');
-var debug = require('debug')('astra-api-facade:server');
+var debug = require('debug')('astra-api-bridge:server');
 var http = require('http');
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "astra-api-facade",
+  "name": "astra-api-bridge",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "astra-api-facade",
+  "name": "astra-api-bridge",
   "version": "0.0.0",
   "private": true,
   "engines": {

--- a/routes/facilities.js
+++ b/routes/facilities.js
@@ -136,18 +136,9 @@ router.get('/campuslist', (req, res, next) => {
  *       - facilities
  *     description: Returns a list of building resources.  Valid filter parameters include having no filters, having a single filter value in both the filterfields and the filtervalues boxes (=), having the same number of values in each box (=), and having a single value in the filterfields box and many values in the filtervalues box ("in").
  *     parameters:
- *       - name: filterfields
- *         description: Create comma delimited string for multiple values
+ *       - name: campus_id
+ *         description: Campus id of the building
  *         in: query
- *         type: string 
- *       - name: filtervalues
- *         description: Create comma delimited string for multiple values
- *         in: query
- *         type: string 
- *       - name: filtertype
- *         description: Select an filtertype
- *         in: query
- *         enum: ["equals_/_in","not_equals/not_in"]
  *         type: string 
  *     produces:
  *       - application/json
@@ -162,16 +153,17 @@ router.get('/buildinglist', (req, res, next) => {
   qb.entity = EntityEnum.BUILDING;
   qb.addFields(['Id', 'Name', 'BuildingCode', 'Campus.Name','IsActive']);
   qb.sort = 'Campus.Name%2CName';
-  qb.queryType = QueryTypeEnum.LIST;  
-  qb.addFilterFields(req.query.filterfields);
-  qb.addFilterValues(req.query.filtervalues);
-  if(req.query.filtertype == 'not_equals/not_in'){
-    qb.equalityFilter = false;
-  };
+  qb.queryType = QueryTypeEnum.ADVANCED;  
+  let campusId = req.query.campus_id;
+
+  if (campusId) {
+    var campusFilter = `CampusId in ("${campusId}")`;
+    qb.advancedFilter = encodeURIComponent(campusFilter);
+  }
+
   const logonUrl = config.defaultApi.url + config.defaultApi.logonEndpoint;
   const buildingsUrl = config.defaultApi.url + config.defaultApi.buildingsEndpoint
   +qb.toQueryString();
-
 
   const credentialData = {
     username: config.defaultApi.username,
@@ -232,18 +224,9 @@ router.get('/buildinglist', (req, res, next) => {
  *       - facilities
  *     description: Returns a list of building resources.  Valid filter parameters include having no filters, having a single filter value in both the filterfields and the filtervalues boxes (=), having the same number of values in each box (=), and having a single value in the filterfields box and many values in the filtervalues box ("in").
  *     parameters:
- *       - name: filterfields
- *         description: Create comma delimited string for multiple values
+ *       - name: building_id
+ *         description: rooms in this building
  *         in: query
- *         type: string 
- *       - name: filtervalues
- *         description: Create comma delimited string for multiple values
- *         in: query
- *         type: string 
- *       - name: filtertype
- *         description: Select an filtertype
- *         in: query
- *         enum: ["equals_/_in","not_equals/not_in"]
  *         type: string 
  *     produces:
  *       - application/json
@@ -260,12 +243,14 @@ router.get('/roomlist', (req, res, next) => {
   qb.addFields(['Id', 'Name', 'roomNumber', 'RoomType.Name']);
   qb.addFields(['Building.Name', 'Building.BuildingCode', 'MaxOccupancy', 'IsActive']);
   qb.sort = '%2BBuilding.Name,Name';
-  qb.queryType = QueryTypeEnum.LIST;  
-  qb.addFilterFields(req.query.filterfields);
-  qb.addFilterValues(req.query.filtervalues);
-  if(req.query.filtertype == 'not_equals/not_in'){
-    qb.equalityFilter = false;
-  };
+  qb.queryType = QueryTypeEnum.ADVANCED;  
+  let buildingId = req.query.building_id;
+
+  if (buildingId) {
+    var buildingFilter = `BuildingId in ("${buildingId}")`;
+    qb.advancedFilter = encodeURIComponent(buildingFilter);
+  }
+  
   const logonUrl = config.defaultApi.url + config.defaultApi.logonEndpoint;
   const roomsUrl = config.defaultApi.url + config.defaultApi.roomsEndpoint
     +qb.toQueryString();

--- a/routes/index.js
+++ b/routes/index.js
@@ -5,7 +5,7 @@ var swaggerUI = require('swagger-ui-express');
 
 var swaggerDefinition = {
   info: {
-    title: 'Astra API Facade',
+    title: 'Astra API Bridge',
     version: '0.0.2',
     description: 'This is a RESTful API that layers on top of the Astra Schedule API',
   },


### PR DESCRIPTION
I'm probably not allowed to hijack the facilities api but if I could... this would allow me to easily use this at the "import" step of spaces, maybe eventually just populate the app directly. 

A ) replace facade with bridge
B ) hijacked the facilities api
- Replaced the general filter abilities with specific campus / building id filters

Open questions - 
- Do we need to spin one of these up for each client, or can we pass the source url and login params in?
- What would I have to change in facilities to make this ok?
- Is it a better idea to replicate these calls in the Spaces api?